### PR TITLE
Fixed bugs

### DIFF
--- a/src/main/java/io/github/antiquitymc/nbt/CompoundTag.java
+++ b/src/main/java/io/github/antiquitymc/nbt/CompoundTag.java
@@ -102,7 +102,7 @@ public final class CompoundTag implements Tag, Map<String, Tag> {
      */
     public double getDouble(String key) {
         if (containsKey(key)) {
-            return ((FloatTag) get(key)).getValue();
+            return ((DoubleTag) get(key)).getValue();
         } else {
             throw new NoSuchElementException(key);
         }

--- a/src/main/java/io/github/antiquitymc/nbt/CompoundTag.java
+++ b/src/main/java/io/github/antiquitymc/nbt/CompoundTag.java
@@ -371,7 +371,7 @@ public final class CompoundTag implements Tag, Map<String, Tag> {
      * @throws ClassCastException if the key is present with an incompatible type
      */
     public /* TODO: @Nullable */ String getString(String key) {
-        return containsKey("key") ? ((StringTag) get(key)).getValue() : null;
+        return containsKey(key) ? ((StringTag) get(key)).getValue() : null;
     }
 
     /**


### PR DESCRIPTION
Bug # 1. Get string used tag "tag" (as a string) instead of actual tag parameter

Bug # 2. CompoundTag#getDouble() casts Tag to FloatTag instead of DoubleTag